### PR TITLE
ArmPkg/SmbiosMiscDxe: Improve Smbios Type00 table population

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -189,7 +189,23 @@
   gArmTokenSpaceGuid.PcdProcessorSerialNumber|L""|VOID*|0x30000073
   gArmTokenSpaceGuid.PcdProcessorAssetTag|L""|VOID*|0x30000074
   gArmTokenSpaceGuid.PcdProcessorPartNumber|L""|VOID*|0x30000075
-
+  ## Enable/Disable the SMBIOS Type00 Bios characteristics. The default
+  #  value is currently enabling the below characteristics.
+  #  PlugAndPlayIsSupported | BiosIsUpgradable | BiosShadowingAllowed |
+  #  BootFromCdIsSupported | SelectableBootIsSupported |
+  #  This Structured PCD is associated with MISC_BIOS_CHARACTERISTICS
+  #  structure that is defined in Include/IndustryStandard/SmBios.h
+  #  @Prompt Enable/Disable Type00 Bios Characteristics.
+  gArmTokenSpaceGuid.PcdBiosCharacteristics|{0x80, 0x9A, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}|MISC_BIOS_CHARACTERISTICS|0x30000076 {
+    <Packages>
+      ArmPkg/ArmPkg.dec
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+  }
+  # This PCD is associated with the BIOSCharacteristicsExtensionBytes[2] field
+  # in the SMBIOS Type00 structure defined in Include/IndustryStandard/SmBios.h
+  # This PCD is initialized to the same values as defined in the data.c
+  gArmTokenSpaceGuid.PcdBiosCharacteristicsExtension|0x0C01|UINT16|0x30000077
   #
   # ARM L2x0 PCDs
   #

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
@@ -79,6 +79,8 @@
   gArmTokenSpaceGuid.PcdBaseBoardProductName
   gArmTokenSpaceGuid.PcdBaseBoardVersion
   gArmTokenSpaceGuid.PcdFdBaseAddress
+  gArmTokenSpaceGuid.PcdBiosCharacteristics
+  gArmTokenSpaceGuid.PcdBiosCharacteristicsExtension
 
 [Guids]
   gEfiGenericVariableGuid

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -153,21 +153,22 @@ GetBiosVersion (
 
 **/
 SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor) {
-  CHAR8               *OptionalStrStart;
-  CHAR8               *StrStart;
-  UINTN               VendorStrLen;
-  UINTN               VerStrLen;
-  UINTN               DateStrLen;
-  UINTN               BiosPhysicalSize;
-  CHAR16              *Vendor;
-  CHAR16              *Version;
-  CHAR16              *ReleaseDate;
-  CHAR16              *Char16String;
-  EFI_STATUS          Status;
-  EFI_STRING_ID       TokenToUpdate;
-  EFI_STRING_ID       TokenToGet;
-  SMBIOS_TABLE_TYPE0  *SmbiosRecord;
-  SMBIOS_TABLE_TYPE0  *InputData;
+  CHAR8                      *OptionalStrStart;
+  CHAR8                      *StrStart;
+  UINTN                      VendorStrLen;
+  UINTN                      VerStrLen;
+  UINTN                      DateStrLen;
+  UINTN                      BiosPhysicalSize;
+  CHAR16                     *Vendor;
+  CHAR16                     *Version;
+  CHAR16                     *ReleaseDate;
+  CHAR16                     *Char16String;
+  EFI_STATUS                 Status;
+  EFI_STRING_ID              TokenToUpdate;
+  EFI_STRING_ID              TokenToGet;
+  SMBIOS_TABLE_TYPE0         *SmbiosRecord;
+  SMBIOS_TABLE_TYPE0         *InputData;
+  MISC_BIOS_CHARACTERISTICS  *BiosChar;
 
   //
   // First check for invalid parameters.
@@ -258,6 +259,11 @@ SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor) {
                                                          (PcdGet16 (PcdEmbeddedControllerFirmwareRelease) >> 8);
   SmbiosRecord->EmbeddedControllerFirmwareMinorRelease = (UINT16)
                                                          (PcdGet16 (PcdEmbeddedControllerFirmwareRelease) & 0xFF);
+
+  BiosChar                                           = (MISC_BIOS_CHARACTERISTICS *)(FixedPcdGetPtr (PcdBiosCharacteristics));
+  SmbiosRecord->BiosCharacteristics                  = *(BiosChar);
+  SmbiosRecord->BIOSCharacteristicsExtensionBytes[0] = (UINT8)(PcdGet16 (PcdBiosCharacteristicsExtension) & 0xFF);
+  SmbiosRecord->BIOSCharacteristicsExtensionBytes[1] = (UINT8)(PcdGet16 (PcdBiosCharacteristicsExtension) >> 8);
 
   OptionalStrStart = (CHAR8 *)(SmbiosRecord + 1);
   UnicodeStrToAsciiStrS (Vendor, OptionalStrStart, VendorStrLen + 1);


### PR DESCRIPTION
Smbios Type00 BiosCharacteristics and BiosCharacteristicsExtensionBytes
are previously hardcoded. This is now changed to PCDs which are initialized
to the previosly hardcoded values. Now the platforms can set this PCDs
based on the customized characteristics enablement.

TEST: Generated the build with this change and tested the smbiosview
output.

Signed-off-by: Thejaswani Putta <tputta@tputta-vm-01.nvidia.com>