### PR TITLE
DynamicTablesPkg: AcpiSsdtPcieLibArm: Allow use of segment number as UID

### DIFF
--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -60,5 +60,8 @@
   # Non BSA Compliant 16550 Serial HID
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdNonBsaCompliant16550SerialHid|""|VOID*|0x40000008
 
+  # Use PCI segment numbers as UID
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdPciUseSegmentAsUid|FALSE|BOOLEAN|0x40000009
+
 [Guids]
   gEdkiiDynamicTablesPkgTokenSpaceGuid = { 0xab226e66, 0x31d8, 0x4613, { 0x87, 0x9d, 0xd2, 0xfa, 0xb6, 0x10, 0x26, 0x3c } }

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieLibArm.inf
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieLibArm.inf
@@ -30,3 +30,6 @@
   AmlLib
   BaseLib
   SsdtPcieSupportLib
+
+[Pcd]
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdPciUseSegmentAsUid


### PR DESCRIPTION
Add support for selecting to use index or segment number as UID and name. This allows the path of the nodes to be well known. For example, if the PCIe node needs to be notified from by an interrupt for a Generic Event Device

Change-Id: Ib1f40ed37920f0eb7c39386064ec1f726f21931c
Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>