### PR TITLE
DynamicTablesPkg: SSDT _LPI revision is incorrect

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyGenerator.c
@@ -482,7 +482,7 @@ GenerateLpiStates (
     }
 
     // We do not support the LevelId field for now, let it to 0.
-    Status = AmlCreateLpiNode (AslName, 1, 0, ScopeNode, &LpiNode);
+    Status = AmlCreateLpiNode (AslName, 0, 0, ScopeNode, &LpiNode);
     if (EFI_ERROR (Status)) {
       ASSERT (0);
       return Status;


### PR DESCRIPTION
_LPI Revision should be 0 per the ACPI 6.5 specification. "The revision number of the _LPI object. Current revision is 0."

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Change-Id: I1637f5acfe92d7e107d855cd2c3f851db5432810