### PR TITLE
DynamicTablesPkg: Allow multiple top level physical nodes

### DIFF
--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -63,5 +63,8 @@
   # Use PCI segment numbers as UID
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdPciUseSegmentAsUid|FALSE|BOOLEAN|0x40000009
 
+  # Force top level container for single socket devices
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdForceTopLevelProcessorContainer|FALSE|BOOLEAN|0x4000000A
+
 [Guids]
   gEdkiiDynamicTablesPkgTokenSpaceGuid = { 0xab226e66, 0x31d8, 0x4613, { 0x87, 0x9d, 0xd2, 0xfa, 0xb6, 0x10, 0x26, 0x3c } }

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyLibArm.inf
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyLibArm.inf
@@ -31,3 +31,7 @@
   AcpiHelperLib
   AmlLib
   BaseLib
+  PcdLib
+
+[Pcd]
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdForceTopLevelProcessorContainer


### PR DESCRIPTION
In SSDT CPU topology generator allow for multiple top level physical nodes as would be seen with a multi-socket system. This will be auto detected if there are more then one physical device and there is a new PCD to enable forcing of a top level processor container to allow for consistency for systems that can be either single or multi socket.

Change-Id: Icc959c48ff5f50be64ef6085cb5110d10ed31054
Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>