### PR TITLE
UnitTestFrameworkPkg/UnitTestLib: Print expected Status on ASSERT fail

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
@@ -290,7 +290,7 @@ UnitTestAssertStatusEqual (
 {
   CHAR8  TempStr[MAX_STRING_SIZE];
 
-  snprintf (TempStr, sizeof (TempStr), "UT_ASSERT_STATUS_EQUAL(%s:%p)", Description, (VOID *)Status);
+  snprintf (TempStr, sizeof (TempStr), "UT_ASSERT_STATUS_EQUAL(%s:%p expected:%p)", Description, (VOID *)Status, (VOID *)Expected);
   _assert_true ((Status == Expected), TempStr, FileName, (INT32)LineNumber);
 
   return (Status == Expected);


### PR DESCRIPTION
Update the UnitTestAssertStatusEqual error message to print out the expected value in addition to the seen value.

Change-Id: Ic651584dcdbcf1f8cd8166ad8058744fc0587d72
Signed-off-by: Jeshua Smith <jeshuas@nvidia.com>