### PR TITLE
MdeModulePkg/DxeCore: Allow relocation of images with large address

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -187,6 +187,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask                   ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdFwVolDxeMaxEncapsulationDepth           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdImageLargeAddressLoad                   ## CONSUMES
 
 # [Hob]
 # RESOURCE_DESCRIPTOR   ## CONSUMES

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -680,7 +680,9 @@ CoreLoadPeImage (
                    );
       }
     } else {
-      if ((Image->ImageContext.ImageAddress >= 0x100000) || Image->ImageContext.RelocationsStripped) {
+      if ((PcdGetBool (PcdImageLargeAddressLoad) && ((Image->ImageContext.ImageAddress) >= 0x100000)) ||
+          Image->ImageContext.RelocationsStripped)
+      {
         Status = CoreAllocatePages (
                    AllocateAddress,
                    (EFI_MEMORY_TYPE)(Image->ImageContext.ImageCodeMemoryType),

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1116,6 +1116,13 @@
   # @Prompt Output MMIO address of Trace Hub message.
   gEfiMdeModulePkgTokenSpaceGuid.PcdTraceHubDebugMmioAddress|0|UINT64|0x30001058
 
+  ## Indicates if images with large load address (>0x100000) should attempted to load at specified location.
+  #  If enabled, attempt to allocate at specfied location will be attempted with a fall back to any address.
+  #   TRUE  - UEFI will attempt to load at specified location.<BR>
+  #   FALSE - UEFI will load at any address<BR>
+  # @Prompt Enable large address image loading.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdImageLargeAddressLoad|TRUE|BOOLEAN|0x30001059
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function


### PR DESCRIPTION
Add PCD to control if modules with start addresses in PE/COFF > 0x100000 attempt to load at specified address.
If a module has an address in this range and there is untested memory DxeCore will attempt to promote all memory to tested which bypasses any memory testing that would occur later in boot.

There are several existing AARCH64 option roms that have base addresses of 0x180000000.


Change-Id: Ic57c668d9bbe27f8a8d787291f5a3f19655ea6a5
Reviewed-on: https://git-master.nvidia.com/r/c/3rdparty/edk2/+/2896350
Reviewed-by: svcacv <svcacv@nvidia.com>
Reviewed-by: svc-mobile-coverity <svc-mobile-coverity@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
GVS: Gerrit_Virtual_Submit <buildbot_gerritrpt@nvidia.com>