### PR TITLE
MdeModulePkg/PciHostBridge: Add support for driver binding

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -46,6 +46,7 @@
   gEfiPciRootBridgeIoProtocolGuid                 ## BY_START
   gEfiPciHostBridgeResourceAllocationProtocolGuid ## BY_START
   gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES
+  gEdkiiPciHostBridgeProtocolGuid                 ## SOMETIMES_CONSUMES
 
 [Depex]
   gEfiCpuIo2ProtocolGuid AND

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridge.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridge.h
@@ -93,6 +93,19 @@ CreateRootBridge (
   IN PCI_ROOT_BRIDGE  *Bridge
   );
 
+/**
+  Free the Pci Root Bridge instance.
+
+  @param Bridge            The root bridge instance.
+
+  @return The pointer to PCI_ROOT_BRIDGE_INSTANCE just created
+          or NULL if creation fails.
+**/
+VOID
+FreeRootBridge (
+  IN PCI_ROOT_BRIDGE_INSTANCE  *Bridge
+  );
+
 //
 // Protocol Member Function Prototypes
 //

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -287,6 +287,30 @@ CreateRootBridge (
 }
 
 /**
+  Free the Pci Root Bridge instance.
+
+  @param Bridge            The root bridge instance.
+
+  @return The pointer to PCI_ROOT_BRIDGE_INSTANCE just created
+          or NULL if creation fails.
+**/
+VOID
+FreeRootBridge (
+  IN PCI_ROOT_BRIDGE_INSTANCE  *Bridge
+  )
+{
+  if (Bridge->ConfigBuffer != NULL) {
+    FreePool (Bridge->ConfigBuffer);
+  }
+
+  if (Bridge->DevicePath != NULL) {
+    FreePool (Bridge->DevicePath);
+  }
+
+  FreePool (Bridge);
+}
+
+/**
   Check parameters for IO,MMIO,PCI read/write services of PCI Root Bridge IO.
 
   The I/O operations are carried out exactly as requested. The caller is

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -692,6 +692,10 @@
   ## Include/Protocol/VariablePolicy.h
   gEdkiiVariablePolicyProtocolGuid = { 0x81D1675C, 0x86F6, 0x48DF, { 0xBD, 0x95, 0x9A, 0x6E, 0x4F, 0x09, 0x25, 0xC3 } }
 
+  ## Include/Library/PciHostBridgeLib.h
+  # Exposes a PCI_HOST_BRIDGE structure for driver binding usage
+  gEdkiiPciHostBridgeProtocolGuid = { 0xaff2b72d, 0x202e, 0x40e3, { 0x82, 0xd5, 0x9f, 0x6f, 0x61, 0xaf, 0x2a, 0x0b } }
+
 [PcdsFeatureFlag]
   ## Indicates if the platform can support update capsule across a system reset.<BR><BR>
   #   TRUE  - Supports update capsule across a system reset.<BR>


### PR DESCRIPTION
If the platform does not support any PCIe devices using the library method allow devices to connect to host bridge via driver binding.


Change-Id: Iaac58fa846ded87a5b59d6c242e4e433b461a5f8