### PR TITLE
dp command without ACPI

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1403,6 +1403,8 @@ ReportFpdtRecordBuffer (
         &BPDTAddr,
         sizeof (UINT64)
         );
+      Status = gBS->InstallConfigurationTable (&gEdkiiFpdtExtendedFirmwarePerformanceGuid, (VOID *)(UINTN)BPDTAddr);
+      ASSERT_EFI_ERROR (Status);
     }
 
     //

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.c
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.c
@@ -129,17 +129,22 @@ EFI_STATUS
 GetBootPerformanceTable (
   )
 {
+  EFI_STATUS                  Status;
   FIRMWARE_PERFORMANCE_TABLE  *FirmwarePerformanceTable;
 
   FirmwarePerformanceTable = (FIRMWARE_PERFORMANCE_TABLE *)EfiLocateFirstAcpiTable (
                                                              EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE
                                                              );
   if (FirmwarePerformanceTable == NULL) {
-    ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_DP_GET_ACPI_FPDT_FAIL), mDpHiiHandle);
-    return EFI_NOT_FOUND;
+    Status = EfiGetSystemConfigurationTable (&gEdkiiFpdtExtendedFirmwarePerformanceGuid, (VOID **)&mBootPerformanceTable);
+    if (EFI_ERROR (Status)) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_DP_GET_ACPI_FPDT_FAIL), mDpHiiHandle);
+      return EFI_NOT_FOUND;
+    }
+  } else {
+    mBootPerformanceTable = (UINT8 *)(UINTN)FirmwarePerformanceTable->BootPointerRecord.BootPerformanceTablePointer;
   }
 
-  mBootPerformanceTable     = (UINT8 *)(UINTN)FirmwarePerformanceTable->BootPointerRecord.BootPerformanceTablePointer;
   mBootPerformanceTableSize = ((BOOT_PERFORMANCE_TABLE *)mBootPerformanceTable)->Header.Length;
 
   return EFI_SUCCESS;

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpApp.inf
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpApp.inf
@@ -54,6 +54,7 @@
 
 [Guids]
   gPerformanceProtocolGuid                                ## CONSUMES ## SystemTable
+  gEdkiiFpdtExtendedFirmwarePerformanceGuid               ## CONSUMES ## SystemTable
 
 [Protocols]
   gEfiLoadedImageProtocolGuid                             ## CONSUMES

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
@@ -55,6 +55,7 @@
 
 [Guids]
   gPerformanceProtocolGuid                                ## CONSUMES ## SystemTable
+  gEdkiiFpdtExtendedFirmwarePerformanceGuid               ## CONSUMES ## SystemTable
 
 [Protocols]
   gEfiLoadedImageProtocolGuid                             ## CONSUMES


### PR DESCRIPTION
Systems that do not boot with ACPI (system that use device tree for example)
can not use the shell dp command. This patch adds this to the configuration
table so that dp command can get this without the FPDT table.

I am open to other ways for this to be passed if desired (Installed protocol, 
handler of the status code, etc) but wanted to post this to at least get thoughts
on this.

-Jeff