### PR TITLE
MdePkg: Remove dependency on mipisyst

### DIFF
--- a/MdePkg/Library/MipiSysTLib/MipiSysTLib.inf
+++ b/MdePkg/Library/MipiSysTLib/MipiSysTLib.inf
@@ -1,7 +1,8 @@
 ## @file
-#  A library providing funcitons to communicate with mipi sys-T submodule.
+#  A library providing functions to communicate with mipi sys-T submodule.
 #
 #  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -36,6 +37,7 @@
   mipi_syst.h
   Platform.c
   Platform.h
+  $(MIPI_HEADER_PATH)/../.
   $(MIPI_HEADER_PATH)/api.h
   $(MIPI_HEADER_PATH)/crc32.h
   $(MIPI_HEADER_PATH)/compiler.h

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -11,6 +11,7 @@
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2023, Ampere Computing LLC. All rights reserved.<BR>
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -29,7 +30,6 @@
   Include
   Test/UnitTest/Include
   Test/Mock/Include
-  Library/MipiSysTLib/mipisyst/library/include
 
 [Includes.IA32]
   Include/Ia32


### PR DESCRIPTION
Rather than include mipisyst headers in MdePkg.dec, reference $(MIPI_HEADER_PATH)/mipi_syst.h in MipiSysTLib.inf's Sources. This will also generate a -I for the path, but only when building MipiSysTLib.  As a result, the mipisyst submodule will only be needed by projects that build MipiSysTLib.