### PR TITLE
BaseTools/GenFw: Change opcode when converting ADR to ADRP

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -1565,6 +1565,7 @@ WriteSections64 (
             Offset = (Sym->st_value - (Rel->r_offset & ~0xfff)) >> 12;
 
             *(UINT32 *)Targ &= 0x9000001f;
+            *(UINT32 *)Targ |= 0x90000000;
             *(UINT32 *)Targ |= ((Offset & 0x1ffffc) << (5 - 2)) | ((Offset & 0x3) << 29);
 
             /* fall through */


### PR DESCRIPTION
In the R_AARCH64_ADR_GOT_PAGE case on AARCH64, be sure to change the opcode to ADRP.  Prior to this change, we updated the address, but not the opcode.

This resolves an issue experienced when building a StandaloneMm image with stack protection enabled on GCC 10.5.  This scenario generates an ADR where an ADRP is more common in other versions of GCC tested.  That explains the obscurity of the issue.  However, an ADR is valid and should be handled by GenFw.

Using the stack protection scenario as an example, the following code is being generated by the toolchain:

    # Load to set the stack canary
    2ffc:	10028020 	adr	x0, 8000 <mErrorString+0x1bc>
    3008:	f940d400 	ldr	x0, [x0, #424]

    # Load to check the stack canary
    30cc:	b0000020 	adrp	x0, 8000 <mErrorString+0x1bc>
    30d0:	f940d400 	ldr	x0, [x0, #424]

GenFw rewrote that to:

    # Load to set the stack canary
    2ffc:	10000480 	adr	x0, 0x308c
    3008:	912ec000 	add	x0, x0, #0xbb0

    # Load to check the stack canary
    30cc:	f0000460 	adrp	x0, 0x92000
    30d0:	912ec000 	add	x0, x0, #0xbb0

Note that we're now setting the stack canary from the wrong address, resulting in an erroneous stack fault.

After this fix, the opcode is also updated, so GenFw rewrites it to:

    2ffc:	90000480 	adrp	x0, 0x92000
    3008:	912ec000 	add	x0, x0, #0xbb0

And the stack canary is set correctly.