### PR TITLE
MdePkg/BaseFdtLib: Rename standard functions

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -12,6 +12,7 @@ import logging
 import os
 import pathlib
 import shutil
+import stat
 import timeit
 from edk2toolext.environment import version_aggregator
 from edk2toolext.environment.plugin_manager import PluginManager
@@ -628,7 +629,7 @@ class UncrustifyCheck(ICiBuildPlugin):
             """
             Private function to attempt to change permissions on file/folder being deleted.
             """
-            os.chmod(path, os.stat.S_IWRITE)
+            os.chmod(path, stat.S_IWRITE)
             func(path)
 
         for _ in range(3):  # retry up to 3 times

--- a/MdePkg/Include/Guid/FileInfo.h
+++ b/MdePkg/Include/Guid/FileInfo.h
@@ -47,6 +47,7 @@ typedef struct {
   UINT64      Attribute;
   ///
   /// The Null-terminated name of the file.
+  /// For a root directory, the name is an empty string.
   ///
   CHAR16      FileName[1];
 } EFI_FILE_INFO;

--- a/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
+++ b/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
@@ -35,3 +35,18 @@ CpuFlushTlb (
   )
 {
 }
+
+/**
+  Determine if the standard CPU signature is "AuthenticAMD".
+
+  @retval TRUE  The CPU signature matches.
+  @retval FALSE The CPU signature does not match.
+**/
+BOOLEAN
+EFIAPI
+StandardSignatureIsAuthenticAMD (
+  VOID
+  )
+{
+  return FALSE;
+}

--- a/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
+++ b/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
@@ -63,13 +63,13 @@ strchr     (
   );
 
 char *
-strrchr    (
+fdt_strrchr    (
   const char *,
   int
   );
 
 unsigned long
-strtoul     (
+fdt_strtoul     (
   const char *,
   char **,
   int
@@ -93,7 +93,10 @@ strcpy (
 #define strnlen(str, count)                 (size_t)(AsciiStrnLenS(str, count))
 #define strncpy(strDest, strSource, count)  AsciiStrnCpyS(strDest, MAX_STRING_SIZE, strSource, (UINTN)count)
 #define strcat(strDest, strSource)          AsciiStrCatS(strDest, MAX_STRING_SIZE, strSource)
+#define strchr(str, ch)                     ScanMem8(str, AsciiStrSize (str), (UINT8)ch)
 #define strcmp(string1, string2, count)     (int)(AsciiStrCmp(string1, string2))
 #define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1, string2, (UINTN)(count)))
+#define strrchr(str, ch)                    fdt_strrchr(str, ch)
+#define strtoul(ptr, end_ptr, base)         fdt_strtoul(ptr, end_ptr, base)
 
 #endif /* FDT_LIB_SUPPORT_H_ */

--- a/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
+++ b/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
@@ -18,28 +18,7 @@
 // so the code gets a bit clunky to handle that case specifically.
 
 char *
-strchr (
-  const char  *Str,
-  int         Char
-  )
-{
-  char  *S;
-
-  S = (char *)Str;
-
-  for ( ; ; S++) {
-    if (*S == Char) {
-      return S;
-    }
-
-    if (*S == '\0') {
-      return NULL;
-    }
-  }
-}
-
-char *
-strrchr (
+fdt_strrchr (
   const char  *Str,
   int         Char
   )
@@ -71,7 +50,7 @@ __isspace (
 }
 
 unsigned long
-strtoul (
+fdt_strtoul (
   const char  *Nptr,
   char        **EndPtr,
   int         Base

--- a/StandaloneMmPkg/Core/Dependency.c
+++ b/StandaloneMmPkg/Core/Dependency.c
@@ -14,16 +14,6 @@
 #include "StandaloneMmCore.h"
 
 ///
-/// EFI_DEP_REPLACE_TRUE - Used to dynamically patch the dependency expression
-///                        to save time.  A EFI_DEP_PUSH is evaluated one an
-///                        replaced with EFI_DEP_REPLACE_TRUE. If PI spec's Vol 2
-///                        Driver Execution Environment Core Interface use 0xff
-///                        as new DEPEX opcode. EFI_DEP_REPLACE_TRUE should be
-///                        defined to a new value that is not conflicting with PI spec.
-///
-#define EFI_DEP_REPLACE_TRUE  0xff
-
-///
 /// Define the initial size of the dependency expression evaluation stack
 ///
 #define DEPEX_STACK_SIZE_INCREMENT  0x1000
@@ -170,12 +160,12 @@ MmIsSchedulable (
   IN  EFI_MM_DRIVER_ENTRY  *DriverEntry
   )
 {
-  EFI_STATUS  Status;
-  UINT8       *Iterator;
-  BOOLEAN     Operator;
-  BOOLEAN     Operator2;
-  EFI_GUID    DriverGuid;
-  VOID        *Interface;
+  EFI_STATUS   Status;
+  CONST UINT8  *Iterator;
+  BOOLEAN      Operator;
+  BOOLEAN      Operator2;
+  EFI_GUID     DriverGuid;
+  VOID         *Interface;
 
   Operator  = FALSE;
   Operator2 = FALSE;
@@ -253,8 +243,7 @@ MmIsSchedulable (
           Status = PushBool (FALSE);
         } else {
           DEBUG ((DEBUG_DISPATCH, "  PUSH GUID(%g) = TRUE\n", &DriverGuid));
-          *Iterator = EFI_DEP_REPLACE_TRUE;
-          Status    = PushBool (TRUE);
+          Status = PushBool (TRUE);
         }
 
         if (EFI_ERROR (Status)) {
@@ -355,18 +344,6 @@ MmIsSchedulable (
 
         DEBUG ((DEBUG_DISPATCH, "  RESULT = %a\n", Operator ? "TRUE" : "FALSE"));
         return Operator;
-
-      case EFI_DEP_REPLACE_TRUE:
-        CopyMem (&DriverGuid, Iterator + 1, sizeof (EFI_GUID));
-        DEBUG ((DEBUG_DISPATCH, "  PUSH GUID(%g) = TRUE\n", &DriverGuid));
-        Status = PushBool (TRUE);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Unexpected error)\n"));
-          return FALSE;
-        }
-
-        Iterator += sizeof (EFI_GUID);
-        break;
 
       default:
         DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Unknown opcode)\n"));


### PR DESCRIPTION
Rename the standard functions in the LibFdtSupport to remove conflicts with other libraries that define them.

Jira TEGRAUEFI-3105


Change-Id: Ib0683a29f9aeb7e9c7fa179e9d495c3e979f1261