### PR TITLE
DynamicTablesPkg/AmlLib: Remove impossible condition

### DIFF
--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
@@ -1349,9 +1349,7 @@ AmlCodeGenRdRegister (
 
   // Cf. ACPI 6.4, s14.7 Referencing the PCC address space
   // The AccessSize represents the Subspace Id for the PCC address space.
-  if (((AddressSpace == EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
-       (AccessSize > 256)) ||
-      ((AddressSpace != EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
+  if (((AddressSpace != EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
        (AccessSize > EFI_ACPI_6_4_QWORD)) ||
       ((NameOpNode == NULL) && (NewRdNode == NULL)))
   {


### PR DESCRIPTION
As AccessSize is a UINT8, it cannot be greater than 256.  Therefore, the condition "AccessSize > 256" is always FALSE.  Removing this part of the conditional in AmlCodeGenRdRegister ().

This resolves a clang error that was introduced when tautological warning overrides were removed from CLANGDWARF.