### PR TITLE
DynamicTablesPkg/SSDT: Remove incorrect root node check

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyGenerator.c
@@ -983,7 +983,6 @@ CreateAmlProcessorContainer (
   @param [in]  NodeFlags        Flags of the ProcNode to check.
   @param [in]  IsLeaf           The ProcNode is a leaf.
   @param [in]  NodeToken        NodeToken of the ProcNode.
-  @param [in]  ParentNodeToken  Parent NodeToken of the ProcNode.
 
   @retval EFI_SUCCESS             Success.
   @retval EFI_INVALID_PARAMETER   Invalid parameter.
@@ -994,26 +993,16 @@ EFIAPI
 CheckProcNode (
   UINT32           NodeFlags,
   BOOLEAN          IsLeaf,
-  CM_OBJECT_TOKEN  NodeToken,
-  CM_OBJECT_TOKEN  ParentNodeToken
+  CM_OBJECT_TOKEN  NodeToken
   )
 {
   BOOLEAN  InvalidFlags;
-  BOOLEAN  HasPhysicalPackageBit;
-  BOOLEAN  IsTopLevelNode;
-
-  HasPhysicalPackageBit = (NodeFlags & EFI_ACPI_6_3_PPTT_PACKAGE_PHYSICAL) ==
-                          EFI_ACPI_6_3_PPTT_PACKAGE_PHYSICAL;
-  IsTopLevelNode = (ParentNodeToken == CM_NULL_TOKEN);
-
-  // A top-level node is a Physical Package and conversely.
-  InvalidFlags = HasPhysicalPackageBit ^ IsTopLevelNode;
 
   // Check Leaf specific flags.
   if (IsLeaf) {
-    InvalidFlags |= ((NodeFlags & PPTT_LEAF_MASK) != PPTT_LEAF_MASK);
+    InvalidFlags = ((NodeFlags & PPTT_LEAF_MASK) != PPTT_LEAF_MASK);
   } else {
-    InvalidFlags |= ((NodeFlags & PPTT_LEAF_MASK) != 0);
+    InvalidFlags = ((NodeFlags & PPTT_LEAF_MASK) != 0);
   }
 
   if (InvalidFlags) {
@@ -1086,8 +1075,7 @@ CreateAmlCpuTopologyTree (
         Status = CheckProcNode (
                    Generator->ProcNodeList[Index].Flags,
                    TRUE,
-                   Generator->ProcNodeList[Index].Token,
-                   NodeToken
+                   Generator->ProcNodeList[Index].Token
                    );
         if (EFI_ERROR (Status)) {
           ASSERT (0);
@@ -1119,8 +1107,7 @@ CreateAmlCpuTopologyTree (
         Status = CheckProcNode (
                    Generator->ProcNodeList[Index].Flags,
                    FALSE,
-                   Generator->ProcNodeList[Index].Token,
-                   NodeToken
+                   Generator->ProcNodeList[Index].Token
                    );
         if (EFI_ERROR (Status)) {
           ASSERT (0);


### PR DESCRIPTION
The code was incorrectly assuming that root nodes had to be physical package nodes and vice versa. This is not always true, so the check is being removed.

Signed-off-by: Jeshua Smith <jeshuas@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
