### PR TITLE
ArmPkg/ProcessorSubClassDxe: Limit CoreCount to 0xFF

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -702,19 +702,37 @@ AddSmbiosProcessorTypeTable (
 
   LegacyVoltage = (UINT8 *)&Type4Record->Voltage;
 
-  *LegacyVoltage                 = MiscProcessorData.Voltage;
-  Type4Record->CurrentSpeed      = MiscProcessorData.CurrentSpeed;
-  Type4Record->MaxSpeed          = MiscProcessorData.MaxSpeed;
-  Type4Record->Status            = ProcessorStatus.Data;
-  Type4Record->L1CacheHandle     = L1CacheHandle;
-  Type4Record->L2CacheHandle     = L2CacheHandle;
-  Type4Record->L3CacheHandle     = L3CacheHandle;
-  Type4Record->CoreCount         = MiscProcessorData.CoreCount;
-  Type4Record->CoreCount2        = MiscProcessorData.CoreCount;
-  Type4Record->EnabledCoreCount  = MiscProcessorData.CoresEnabled;
+  *LegacyVoltage             = MiscProcessorData.Voltage;
+  Type4Record->CurrentSpeed  = MiscProcessorData.CurrentSpeed;
+  Type4Record->MaxSpeed      = MiscProcessorData.MaxSpeed;
+  Type4Record->Status        = ProcessorStatus.Data;
+  Type4Record->L1CacheHandle = L1CacheHandle;
+  Type4Record->L2CacheHandle = L2CacheHandle;
+  Type4Record->L3CacheHandle = L3CacheHandle;
+
+  if (MiscProcessorData.CoreCount > 255) {
+    Type4Record->CoreCount = 0xFF;
+  } else {
+    Type4Record->CoreCount = MiscProcessorData.CoreCount;
+  }
+
+  Type4Record->CoreCount2 = MiscProcessorData.CoreCount;
+
+  if (MiscProcessorData.CoresEnabled > 255) {
+    Type4Record->EnabledCoreCount = 0xFF;
+  } else {
+    Type4Record->EnabledCoreCount = MiscProcessorData.CoresEnabled;
+  }
+
   Type4Record->EnabledCoreCount2 = MiscProcessorData.CoresEnabled;
-  Type4Record->ThreadCount       = MiscProcessorData.ThreadCount;
-  Type4Record->ThreadCount2      = MiscProcessorData.ThreadCount;
+
+  if (MiscProcessorData.ThreadCount > 255) {
+    Type4Record->ThreadCount = 0xFF;
+  } else {
+    Type4Record->ThreadCount = MiscProcessorData.ThreadCount;
+  }
+
+  Type4Record->ThreadCount2 = MiscProcessorData.ThreadCount;
 
   Type4Record->CurrentSpeed  = GetCpuFrequency (ProcessorIndex);
   Type4Record->ExternalClock =


### PR DESCRIPTION
 The CoreCount and EnabledCore counts should be set to 0xFF if value is
 greater than 255 per the SMBIOS specification.


Change-Id: I8e3e6e519d4444575a4573d24ac0d291aec532f0 Reviewed-on: https://git-master.nvidia.com/r/c/3rdparty/edk2/+/2828322
Reviewed-by: svcacv <svcacv@nvidia.com>
Reviewed-by: Nick Ramirez <nramirez@nvidia.com>
GVS: Gerrit_Virtual_Submit <buildbot_gerritrpt@nvidia.com>
(cherry picked from commit 2a5998a59dada5d04824ce28f8d039c3ba5a6a30) Reviewed-on: https://git-master.nvidia.com/r/c/3rdparty/edk2/+/2832413
Reviewed-by: svc-sw-mobile-l4t <svc-sw-mobile-l4t@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>