### PR TITLE
ArmPkg/CompilerIntrinsicsLib: provide __ashlti3

### DIFF
--- a/ArmPkg/Library/CompilerIntrinsicsLib/AArch64/ashlti3.S
+++ b/ArmPkg/Library/CompilerIntrinsicsLib/AArch64/ashlti3.S
@@ -1,0 +1,33 @@
+#------------------------------------------------------------------------------
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#------------------------------------------------------------------------------
+
+#include <AsmMacroIoLib.h>
+
+ASM_FUNC(__ashlti3)
+  # return if shift is 0
+  cbz x2, 1f
+
+  mov x3, #64
+  sub x3, x3, x2
+  cmp x3, #0
+  b.le 2f
+
+  # shift is <= 64 bits
+  lsr x3, x0, x3
+  lsl x1, x1, x2
+  orr x1, x1, x3
+  lsl x0, x0, x2
+1:
+  ret
+
+2:
+  # shift is > 64
+  neg w3, w3
+  lsl x1, x0, x3
+  mov x0, #0
+  ret

--- a/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+++ b/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
@@ -66,6 +66,7 @@
 
 [Sources.AARCH64]
   AArch64/Atomics.S    | GCC
+  AArch64/ashlti3.S    | GCC
 
 [Packages]
   MdePkg/MdePkg.dec


### PR DESCRIPTION
The compiler will use this function if it is left shifting a 128 bit value.

Bug 4452263

Change-Id: I19d8f51e2540dca6f1fee8de583a6b57d0cec240