### PR TITLE
pip-requirements.txt: Hold setuptools to <80.9

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -18,3 +18,4 @@ edk2-basetools==0.1.48
 antlr4-python3-runtime==4.7.1
 lcov-cobertura==2.0.2
 regex==2023.8.8
+setuptools<80.9


### PR DESCRIPTION
pkg_resources may be removed in setuptools 81.x.  Avoid installing setuptools 81.x until we can remove our dependency on pkg_resources.

Also, avoid 80.9.x, which only adds the warning that pkg_resources will be removed. But sticking with <80.9, we can remove the warning as well.